### PR TITLE
改為手動發布版本

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -1,9 +1,7 @@
 name: Create Alpha Release
 
 on:
-  push:
-    branches:
-      - alpha-release
+  workflow_dispatch:
 
 jobs:
   build-and-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Create Release
 
 on:
-  push:
-    branches:
-      - release
+  workflow_dispatch:
 
 jobs:
   build-and-release:


### PR DESCRIPTION
此修改必須放在此版本庫的 default branch 才會生效。引入此修改後可從 Actions 手動操作在任意 branch 上執行 workflow。

![圖片](https://github.com/user-attachments/assets/f20b0a4f-97c0-4b96-b94e-36140de59a9d)

一般而言 release 分支是比較複雜的專案使用，作用是在團隊其他成員開發其他功能時，負責發布的團隊在此分支上做發布前的準備，包括撰寫文件，更新說明，或緊急修復 bug 等等，發布完成後通常會 merge 回主要開發分支。因此此分支上可能會多次 push 不同內容，此修改也取消了原先 push 到 release branch 即自動發布的行為，以免 push 內容即意外發布新版。

此專案規模不大，不一定需要 release / alpha-rlease 分支，可以考慮刪除，直接在 main 分支寫好東西後就手動發布，以精簡版本線圖，避免不必要的分支與合併。團隊如要維持原來做法也可以，不影響引進本功能。