### PR TITLE
優化影像學報告展開箭頭顯示邏輯

### DIFF
--- a/src/components/tabs/ImagingData.jsx
+++ b/src/components/tabs/ImagingData.jsx
@@ -467,6 +467,9 @@ const ReportImagingTable = ({ data, generalDisplaySettings }) => {
               }
             }
 
+            // 判斷報告是否有被縮減
+            const isReportReduced = simplifiedReport !== fullReport;
+
             // 根據展開狀態選擇顯示的內容
             const displayReport = isExpanded ? fullReport : simplifiedReport;
 
@@ -512,25 +515,27 @@ const ReportImagingTable = ({ data, generalDisplaySettings }) => {
                 </TableCell>
                 <TableCell>
                   <Box sx={{ position: 'relative' }}>
-                    {/* 展開/收合按鈕 - 右上角 */}
-                    <IconButton
-                      size="small"
-                      onClick={() => toggleExpand(index)}
-                      sx={{
-                        position: 'absolute',
-                        top: 0,
-                        right: 0,
-                        zIndex: 1
-                      }}
-                    >
-                      {isExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
-                    </IconButton>
+                    {/* 展開/收合按鈕 - 只在報告有被縮減時顯示 */}
+                    {isReportReduced && (
+                      <IconButton
+                        size="small"
+                        onClick={() => toggleExpand(index)}
+                        sx={{
+                          position: 'absolute',
+                          top: 0,
+                          right: 0,
+                          zIndex: 1
+                        }}
+                      >
+                        {isExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+                      </IconButton>
+                    )}
 
                     {/* 報告內容 */}
                     <TypographySizeWrapper
                       textSizeType="content"
                       generalDisplaySettings={generalDisplaySettings}
-                      sx={{ pr: 4 }}
+                      sx={{ pr: isReportReduced ? 4 : 0 }}
                     >
                       {(() => {
                         // Highlight specific terms in red


### PR DESCRIPTION
## 摘要
優化影像學報告的展開/收合箭頭顯示邏輯，只在報告經過縮減時才顯示箭頭，讓使用者一眼就能分辨哪些報告有折疊內容。

## 改動內容
- 新增 `isReportReduced` 判斷邏輯，比對完整報告與簡化報告
- 條件渲染展開/收合按鈕，僅在報告被縮減時顯示
- 動態調整報告內容 padding，避免按鈕遮擋文字

## 測試結果
- ✅ 有縮減的報告：顯示展開箭頭，可切換完整/簡化版本
- ✅ 無縮減的報告：不顯示箭頭，直接顯示完整內容
- ✅ 排版正常，使用 MUI v6 確保相容性

## 相關 Commits
- 861171f - feat: 優化影像學報告展開箭頭顯示邏輯