### PR TITLE
feat: 新增檢驗項目趨勢圖 popover 功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^6.5.0",
     "@mui/material": "^6.5.0",
+    "@mui/x-charts": "^8.28.2",
     "@vitejs/plugin-react": "^4.3.4",
     "esbuild": "^0.25.1",
     "react": "^19.0.0",

--- a/src/components/tabs/LabData.jsx
+++ b/src/components/tabs/LabData.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Box, Divider, Snackbar } from "@mui/material";
 import TypographySizeWrapper from "../utils/TypographySizeWrapper";
 
@@ -12,9 +12,6 @@ import { formatLabItemForCopy, formatDate } from "../utils/lab/LabUtilities";
 import { labCopyFormatter } from "../../utils/labCopyFormatter";
 
 const LabData = ({ groupedLabs, settings, labSettings, generalDisplaySettings }) => {
-  // Add detailed logging to see what's coming in from props
-  console.log("LabData props:", { settings, labSettings, displayLabFormat: labSettings?.displayLabFormat });
-  
   // 添加搜尋功能狀態
   const [searchText, setSearchText] = useState("");
   const [filteredGroupedLabs, setFilteredGroupedLabs] = useState(groupedLabs);
@@ -54,19 +51,11 @@ const LabData = ({ groupedLabs, settings, labSettings, generalDisplaySettings })
 
   // Function to map format names (handles legacy formats and ensures valid values)
   const mapFormatName = (format) => {
-    // Log format value for debugging
-    console.log("FORMAT VALUE TO MAP:", format);
+    if (format === undefined || format === null) return 'byType';
 
-    // Check if format is undefined or null, return default
-    if (format === undefined || format === null) {
-      console.log("FORMAT UNDEFINED/NULL, RETURNING DEFAULT");
-      return 'byType';
-    }
-
-    // Map of supported format names
     const formatMap = {
-      'columns': 'twoColumn',    // Legacy format name
-      'column': 'twoColumn',     // Handle possible typo
+      'columns': 'twoColumn',
+      'column': 'twoColumn',
       'twoColumn': 'twoColumn',
       'threeColumn': 'threeColumn',
       'byType': 'byType',
@@ -74,14 +63,7 @@ const LabData = ({ groupedLabs, settings, labSettings, generalDisplaySettings })
       'horizontal': 'horizontal'
     };
 
-    // Check if this is a valid format and return mapped value (or default)
-    if (formatMap[format]) {
-      console.log(`MAPPED FORMAT from ${format} to ${formatMap[format]}`);
-      return formatMap[format];
-    } else {
-      console.log(`INVALID FORMAT: ${format}, DEFAULTING TO byType`);
-      return 'byType';
-    }
+    return formatMap[format] || 'byType';
   };
 
   // Ensure all required properties exist in labSettings with defaults
@@ -98,17 +80,6 @@ const LabData = ({ groupedLabs, settings, labSettings, generalDisplaySettings })
     // Ensure display format is properly mapped
     displayLabFormat: mapFormatName(labSettings?.displayLabFormat)
   };
-
-  // Log to help debug the display format
-  console.log("Lab settings after merge:", completeLabSettings);
-  console.log("Original format in props:", labSettings?.displayLabFormat);
-  console.log("Mapped display format:", completeLabSettings.displayLabFormat);
-
-  // Add an effect to respond to labSettings changes
-  useEffect(() => {
-    console.log("labSettings prop changed:", labSettings);
-    console.log("Current displayLabFormat:", labSettings?.displayLabFormat);
-  }, [labSettings]);
 
   // 使用自定義 Hook 處理複製功能
   const {
@@ -329,20 +300,6 @@ const LabData = ({ groupedLabs, settings, labSettings, generalDisplaySettings })
       });
   };
 
-  // 使用 Map 來取代 switch-case 結構
-  // # zh-TW: 使用 Map 定義不同顯示格式對應的欄數
-  const columnCountMap = new Map([
-    ["twoColumn", 2],
-    ["threeColumn", 3],
-    ["byType", 0],  // 特殊情況，按類型分群
-    ["default", 1]  // 'vertical' 或其他情況
-  ]);
-
-  // 確定欄數設置
-  const getColumnCount = () => {
-    return columnCountMap.get(completeLabSettings.displayLabFormat) || columnCountMap.get("default");
-  };
-
   // 使用 Map 來儲存不同的布局組件
   // # zh-TW: 使用 Map 來決定要渲染的布局組件
   const layoutComponentMap = new Map([
@@ -413,14 +370,14 @@ const LabData = ({ groupedLabs, settings, labSettings, generalDisplaySettings })
   return (
     <>
       {/* 添加搜尋欄 */}
-      <LabSearch 
+      <LabSearch
         searchText={searchText}
         handleSearchChange={handleSearchChange}
         generalDisplaySettings={generalDisplaySettings}
         labSettings={completeLabSettings}
         onCopyAll={handleCopyAllLabData}
       />
-      
+
       {filteredGroupedLabs.length === 0 ? (
         <TypographySizeWrapper
           color="text.secondary"

--- a/src/components/tabs/LabTableView.jsx
+++ b/src/components/tabs/LabTableView.jsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { labProcessor } from '../../utils/labProcessor';
 import TypographySizeWrapper from "../utils/TypographySizeWrapper";
+import LabItemTrendPopover from "./lab/LabItemTrendPopover";
 
 const LabTableView = ({ groupedLabs, labSettings, generalDisplaySettings }) => {
   // console.log("LabTableView rendering with lab settings:", labSettings);
@@ -279,14 +280,17 @@ const LabTableView = ({ groupedLabs, labSettings, generalDisplaySettings }) => {
                     }
                   }}
                 >
-                  <TypographySizeWrapper
-                    variant="body2"
-                    textSizeType="content"
-                    generalDisplaySettings={generalDisplaySettings}
-                    fontWeight="medium"
-                  >
-                    {item.displayName}
-                  </TypographySizeWrapper>
+                  <LabItemTrendPopover item={item} dates={dates}>
+                    <TypographySizeWrapper
+                      variant="body2"
+                      textSizeType="content"
+                      generalDisplaySettings={generalDisplaySettings}
+                      fontWeight="medium"
+                      sx={{ textDecoration: 'underline dotted', textDecorationColor: '#bdbdbd' }}
+                    >
+                      {item.displayName}
+                    </TypographySizeWrapper>
+                  </LabItemTrendPopover>
                 </TableCell>
 
                 {dates.map((dateInfo, dateIndex) => {

--- a/src/components/tabs/lab/LabItemTrendPopover.jsx
+++ b/src/components/tabs/lab/LabItemTrendPopover.jsx
@@ -1,0 +1,224 @@
+import { useState, useRef } from "react";
+import { Box, Popover, Typography } from "@mui/material";
+import { LineChart } from "@mui/x-charts/LineChart";
+import { useXScale, useYScale, useDrawingArea } from "@mui/x-charts/hooks";
+
+// 手動渲染 X 軸日期標籤（繞過內建 tick label，避免被 clipPath 遮住）
+const XAxisLabels = ({ chartData }) => {
+  const xScale = useXScale();
+  const { top, height } = useDrawingArea();
+  const y = top + height + 22;
+
+  return (
+    <>
+      {chartData.map((d, i) => {
+        const x = xScale(d.label);
+        if (x == null) return null;
+        return (
+          <text
+            key={i}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            fontSize={13}
+            fill="#555"
+            style={{ pointerEvents: "none", userSelect: "none" }}
+          >
+            {d.label}
+          </text>
+        );
+      })}
+    </>
+  );
+};
+
+// 定義在元件外，避免每次 render 產生新的 component type reference
+// 在 LineChart 的 SVG context 內渲染，透過 chart hooks 取得座標
+const DataLabels = ({ chartData }) => {
+  const xScale = useXScale();
+  const yScale = useYScale();
+
+  return (
+    <>
+      {chartData.map((d, i) => {
+        const x = xScale(d.label);
+        const y = yScale(d.value);
+        if (x == null || y == null) return null;
+        // 第一個點：往右上偏移，避免與Y軸數值重疊
+        const offsetX = i === 0 ? 10 : 0;
+        const anchor = i === 0 ? "start" : "middle";
+        return (
+          <text
+            key={i}
+            x={x + offsetX}
+            y={y - 10}
+            textAnchor={anchor}
+            fontSize={16}
+            fill="#1976d2"
+            fontWeight="bold"
+            style={{ pointerEvents: "none", userSelect: "none" }}
+          >
+            {d.value}
+          </text>
+        );
+      })}
+    </>
+  );
+};
+
+const LabItemTrendPopover = ({ item, dates, children }) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const closeTimer = useRef(null);
+
+  // 將 dates（新→舊）反轉為舊→新，只保留有數值的日期
+  const chartData = [...dates]
+    .reverse()
+    .map(d => {
+      const dateKey = `${d.date}_${d.hosp}`;
+      const entry = item.values[dateKey];
+      if (!entry) return null;
+      const numVal = parseFloat(entry.value);
+      if (isNaN(numVal)) return null;
+      const parts = d.date.split("-");
+      const label = parts.length === 3 ? `${parts[0].slice(2)}/${parts[1]}/${parts[2]}` : d.date;
+      return {
+        label,
+        value: numVal,
+        unit: entry.unit || "",
+        referenceMin: entry.referenceMin != null ? Number(entry.referenceMin) : null,
+        referenceMax: entry.referenceMax != null ? Number(entry.referenceMax) : null,
+      };
+    })
+    .filter(Boolean);
+
+  if (chartData.length < 2) return children;
+
+  const unit = chartData[0]?.unit || "";
+
+  const refMins = chartData.map(d => d.referenceMin);
+  const refMaxs = chartData.map(d => d.referenceMax);
+  const hasRefMin = refMins.some(v => v != null);
+  const hasRefMax = refMaxs.some(v => v != null);
+
+  // Y 軸範圍：取資料值與上下限的聯集，加 15% padding，不低於 0
+  const dataValues = chartData.map(d => d.value);
+  const validRefMins = refMins.filter(v => v != null);
+  const validRefMaxs = refMaxs.filter(v => v != null);
+  const effectiveMin = Math.min(...dataValues, ...validRefMins);
+  const effectiveMax = Math.max(...dataValues, ...validRefMaxs);
+  const rangePad = (effectiveMax - effectiveMin) * 0.15 || effectiveMax * 0.1;
+  const yMin = Math.max(0, effectiveMin - rangePad);
+  const yMax = effectiveMax + rangePad;
+
+  const series = [
+    {
+      id: "main",
+      data: chartData.map(d => d.value),
+      showMark: true,
+      color: "#1976d2",
+      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
+    },
+  ];
+
+  if (hasRefMax) {
+    series.push({
+      id: "refMax",
+      data: refMaxs,
+      showMark: false,
+      color: "#e57373",
+      label: "上限",
+      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
+    });
+  }
+
+  if (hasRefMin) {
+    series.push({
+      id: "refMin",
+      data: refMins,
+      showMark: false,
+      color: "#388e3c",
+      label: "下限",
+      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
+    });
+  }
+
+  const openPopover = (event) => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    setAnchorEl(event.currentTarget);
+  };
+
+  const scheduleClose = () => {
+    closeTimer.current = setTimeout(() => setAnchorEl(null), 150);
+  };
+
+  const cancelClose = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+  };
+
+  return (
+    <>
+      <Box
+        onMouseEnter={openPopover}
+        onMouseLeave={scheduleClose}
+        onClick={(e) => setAnchorEl(anchorEl ? null : e.currentTarget)}
+        sx={{ cursor: "pointer", display: "inline-block" }}
+      >
+        {children}
+      </Box>
+
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        anchorOrigin={{ vertical: "center", horizontal: "right" }}
+        transformOrigin={{ vertical: "center", horizontal: "left" }}
+        disableRestoreFocus
+        disableScrollLock
+        sx={{ pointerEvents: "none" }}
+        slotProps={{
+          paper: {
+            onMouseEnter: cancelClose,
+            onMouseLeave: scheduleClose,
+            sx: { pointerEvents: "auto", p: 1.5, ml: 2 },
+            elevation: 4,
+          },
+        }}
+      >
+        <Typography variant="subtitle2" color="primary" sx={{ fontSize: "1.2rem", fontWeight: 600 }}>
+          {item.displayName}
+          {unit ? ` (${unit})` : ""}
+        </Typography>
+
+        <LineChart
+          xAxis={[{
+            data: chartData.map(d => d.label),
+            scaleType: "point",
+            tickLabelStyle: { display: "none" },
+          }]}
+          yAxis={[{ min: yMin, max: yMax, tickLabelStyle: { fontSize: 15 } }]}
+          series={series}
+          height={420}
+          width={660}
+          margin={{ left: 65, right: 55, top: 30, bottom: 65 }}
+          slotProps={{ legend: { hidden: true } }}
+          tooltip={{ trigger: "axis" }}
+          sx={{
+            "& svg": { overflow: "visible" },
+            "& .MuiLineElement-series-refMax": {
+              strokeDasharray: "6 3",
+              strokeWidth: 1.5,
+            },
+            "& .MuiLineElement-series-refMin": {
+              strokeDasharray: "6 3",
+              strokeWidth: 1.5,
+            },
+          }}
+        >
+          <DataLabels chartData={chartData} />
+          <XAxisLabels chartData={chartData} />
+        </LineChart>
+      </Popover>
+    </>
+  );
+};
+
+export default LabItemTrendPopover;


### PR DESCRIPTION
在 LabTableView 左欄的檢驗項目名稱上，hover 或點擊即可彈出
該項目的歷次數值折線圖，包含：
- 藍色實線顯示實際數值，點旁標示數字
- 紅色虛線顯示正常值上限，綠色虛線顯示下限
- Y 軸自動依資料範圍加 15% padding
- X 軸顯示年月日（yy/mm/dd 格式）
- 滑鼠移入視窗有 150ms 延遲關閉，方便互動