### PR TITLE
fix/feat: eGFR 公式區分、癌症篩檢新項目、imue0080s05 端點支援

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -26,7 +26,8 @@ const API_ENDPOINTS = {
   chinesemed: "medcloud2.nhi.gov.tw/imu/api/imue0090/imue0090s02/get-data",
   imaging: "medcloud2.nhi.gov.tw/imu/api/imue0130/imue0130s02/get-data",
   medication: "medcloud2.nhi.gov.tw/imu/api/imue0008/imue0008s02/get-data",
-  labdata: "medcloud2.nhi.gov.tw/imu/api/imue0060/imue0060s02/get-data"
+  labdata: "medcloud2.nhi.gov.tw/imu/api/imue0060/imue0060s02/get-data",
+  imue0080s05: "medcloud2.nhi.gov.tw/imu/api/imue0080/imue0080s05/get-data"
 };
 
 // Add listeners for all API endpoints
@@ -74,7 +75,8 @@ const DATA_TYPE_TO_STORAGE_KEY = {
   'surgery': 'surgeryData',
   'discharge': 'dischargeData',
   'medDays': 'medDaysData',
-  'patientSummary': 'patientSummaryData'
+  'patientSummary': 'patientSummaryData',
+  'imue0080s05': 'imue0080s05Data'
 };
 
 // 動作與處理函數的映射
@@ -174,6 +176,7 @@ const ACTION_HANDLERS = new Map([
   ['saveDischargeData', saveDataHandler('discharge')],
   ['saveMedDaysData', saveDataHandler('medDays')],
   ['savePatientSummaryData', saveDataHandler('patientSummary')],
+  ['saveImue0080s05Data', saveDataHandler('imue0080s05')],
   
   ['saveToken', (message, sender, sendResponse) => {
     // console.log("Background script received token to save");

--- a/src/components/tabs/Overview_CancerScreening.jsx
+++ b/src/components/tabs/Overview_CancerScreening.jsx
@@ -42,14 +42,14 @@ const Overview_CancerScreening = ({ cancerScreeningData, generalDisplaySettings 
     // 嘗試從 originalData.robject 取得資料
     const dataFromOriginal = combinedData.originalData && combinedData.originalData.robject;
     // 或者直接從 combinedData（舊格式）
-    const dataFromDirect = combinedData.colorectal || combinedData.oralMucosa || combinedData.mammography || combinedData.papSmears || combinedData.lungCancer;
+    const dataFromDirect = combinedData.colorectal || combinedData.oralMucosa || combinedData.mammography || combinedData.papSmears || combinedData.lungCancer || combinedData.papillomavirus || combinedData.helicobacter;
 
     const actualData = dataFromRObject || dataFromOriginal || (dataFromDirect ? combinedData : null);
 
     // 癌症篩檢的資料結構不同，檢查是否有任何篩檢項目
     const result = (
       actualData &&
-      (actualData.colorectal || actualData.oralMucosa || actualData.mammography || actualData.papSmears || actualData.lungCancer)
+      (actualData.colorectal || actualData.oralMucosa || actualData.mammography || actualData.papSmears || actualData.lungCancer || actualData.papillomavirus || actualData.helicobacter)
     );
     return result;
   };
@@ -82,7 +82,7 @@ const Overview_CancerScreening = ({ cancerScreeningData, generalDisplaySettings 
     // 取得實際資料（支援多種格式）
     const dataFromRObject = combinedData.rObject && combinedData.rObject[0];
     const dataFromOriginal = combinedData.originalData && combinedData.originalData.robject;
-    const dataFromDirect = (combinedData.colorectal || combinedData.oralMucosa || combinedData.mammography || combinedData.papSmears || combinedData.lungCancer) ? combinedData : null;
+    const dataFromDirect = (combinedData.colorectal || combinedData.oralMucosa || combinedData.mammography || combinedData.papSmears || combinedData.lungCancer || combinedData.papillomavirus || combinedData.helicobacter) ? combinedData : null;
 
     const actualData = dataFromRObject || dataFromOriginal || dataFromDirect;
 
@@ -163,6 +163,8 @@ const Overview_CancerScreening = ({ cancerScreeningData, generalDisplaySettings 
           {renderScreeningItem('mammography', '乳房攝影')}
           {renderScreeningItem('papSmears', '子宮頸癌')}
           {renderScreeningItem('lungCancer', '肺癌篩檢')}
+          {renderScreeningItem('papillomavirus', 'HPV')}
+          {renderScreeningItem('helicobacter', '胃癌篩檢')}
         </Box>
       ) : (
         <Typography

--- a/src/components/tabs/Overview_LabTests.jsx
+++ b/src/components/tabs/Overview_LabTests.jsx
@@ -305,20 +305,22 @@ const Overview_LabTests = ({ groupedLabs = [], labData, overviewSettings = {}, g
                   // 使用 Map 為特殊處理的測試類型定義處理邏輯
                   const specialTestHandlers = new Map([
                     ['09015C', () => {
-                      // 使用 abbrName 來判斷是否為 GFR
-                      let displayName = 'Cr';  // 默認為 Cr
+                      let displayName = 'Cr';
+                      const isGFR = lab.abbrName === 'eGFR' || lab.abbrName === 'eGFR(MDRD)' ||
+                                    (lab.itemName && (lab.itemName.includes('GFR') ||
+                                                     lab.itemName.includes('腎絲球過濾率') ||
+                                                     lab.itemName.includes('Ccr')));
+                      if (isGFR) displayName = 'eGFR';
 
-                      if (lab.abbrName === 'GFR' ||
-                          (lab.itemName && (lab.itemName.includes('GFR') ||
-                                           lab.itemName.includes('腎絲球過濾率') ||
-                                           lab.itemName.includes('Ccr')))) {
-                        displayName = 'GFR';
-                      }
+                      // 標記是否為 CKD-EPI 新公式，供後續優先選值使用
+                      const isCKDEPI = isGFR && lab.abbrName !== 'eGFR(MDRD)' &&
+                                       !(lab.itemName && lab.itemName.includes('MDRD'));
 
                       matchingTests.push({
                         ...lab,
                         date: labGroup.date,
-                        displayName: displayName
+                        displayName,
+                        _isCKDEPI: isCKDEPI
                       });
                     }],
                     ['09040C', () => {
@@ -392,7 +394,7 @@ const Overview_LabTests = ({ groupedLabs = [], labData, overviewSettings = {}, g
                                               test.orderCode !== '12111C' &&
                                               !test.orderCode.startsWith('08011C-'))
                 .map(test => test.displayName),
-              'GFR', 'Cr', 'UPCR', 'UACR', 'WBC', 'Hb', 'PLT'
+              'eGFR', 'Cr', 'UPCR', 'UACR', 'WBC', 'Hb', 'PLT'
             ];
 
             // Debug the display names being used
@@ -418,10 +420,15 @@ const Overview_LabTests = ({ groupedLabs = [], labData, overviewSettings = {}, g
 
               // Only process if this test type and date should be shown
               if (testsByTypeAndDate[displayName] && uniqueDates.includes(date)) {
-                // If we already have a value for this test type and date, keep the newer one
-                if (testsByTypeAndDate[displayName][date] === null ||
-                    (test.timestamp && testsByTypeAndDate[displayName][date].timestamp &&
-                     test.timestamp > testsByTypeAndDate[displayName][date].timestamp)) {
+                const existing = testsByTypeAndDate[displayName][date];
+                if (existing === null) {
+                  testsByTypeAndDate[displayName][date] = test;
+                } else if (displayName === 'eGFR' && test._isCKDEPI && !existing._isCKDEPI) {
+                  // CKD-EPI 新公式優先於 MDRD 舊公式
+                  testsByTypeAndDate[displayName][date] = test;
+                } else if (displayName !== 'eGFR' &&
+                           test.timestamp && existing.timestamp &&
+                           test.timestamp > existing.timestamp) {
                   testsByTypeAndDate[displayName][date] = test;
                 }
               } else {
@@ -451,7 +458,7 @@ const Overview_LabTests = ({ groupedLabs = [], labData, overviewSettings = {}, g
                 ['08011C-WBC', 'WBC'],
                 ['08011C-Hb', 'Hb'],
                 ['08011C-Platelet', 'PLT'],
-                ['09015C', ['Cr', 'GFR']],
+                ['09015C', ['Cr', 'eGFR']],
                 ['09040C', 'UPCR'],
                 ['12111C', 'UACR']
               ]);
@@ -561,7 +568,17 @@ const Overview_LabTests = ({ groupedLabs = [], labData, overviewSettings = {}, g
                               sx={cellStyles}
                             >
                               <TypographySizeWrapper variant="body2" generalDisplaySettings={generalDisplaySettings}>
-                                {test ? (test.value || test.result || '') : <span style={{ color: '#aaaaaa' }}>—</span>}
+                                {test ? (
+                                  (displayName === 'eGFR' && test.hasMultipleValues && test.valueRange)
+                                    ? (() => {
+                                        const min = test.valueRange.min;
+                                        const max = test.valueRange.max;
+                                        const minDec = (min.toString().split('.')[1] || '').length;
+                                        const maxDec = (max.toString().split('.')[1] || '').length;
+                                        return minDec <= maxDec ? min : max;
+                                      })()
+                                    : (test.value || test.result || '')
+                                ) : <span style={{ color: '#aaaaaa' }}>—</span>}
                               </TypographySizeWrapper>
                             </TableCell>
                           );

--- a/src/components/tabs/lab/LabItemTrendPopover.jsx
+++ b/src/components/tabs/lab/LabItemTrendPopover.jsx
@@ -3,74 +3,186 @@ import { Box, Popover, Typography } from "@mui/material";
 import { LineChart } from "@mui/x-charts/LineChart";
 import { useXScale, useYScale, useDrawingArea } from "@mui/x-charts/hooks";
 
-// 手動渲染 X 軸日期標籤（繞過內建 tick label，避免被 clipPath 遮住）
-const XAxisLabels = ({ chartData }) => {
+const MIN_WIDTH = 660;
+const MAX_WIDTH = 900;
+const PX_PER_POINT = 40;
+const MIN_PX_GAP = 62; // 足以容納最長數值標籤（~50px）加上間距
+
+// 合併數值標籤與 X 軸日期標籤，共用同一套 pixel-distance 過濾邏輯
+// 依優先級排序候選點，相鄰間距 < MIN_PX_GAP 的點略過
+const ChartLabels = ({ chartData, candidateIndices }) => {
   const xScale = useXScale();
+  const yScale = useYScale();
   const { top, height } = useDrawingArea();
-  const y = top + height + 22;
+  const dateY = top + height + 22;
+
+  // 依優先級逐一放置，太近則跳過
+  const placedX = [];
+  const visibleIndices = new Set();
+  for (const i of candidateIndices) {
+    const x = xScale(chartData[i].label);
+    if (x == null) continue;
+    if (!placedX.some(px => Math.abs(px - x) < MIN_PX_GAP)) {
+      placedX.push(x);
+      visibleIndices.add(i);
+    }
+  }
 
   return (
     <>
       {chartData.map((d, i) => {
+        if (!visibleIndices.has(i)) return null;
         const x = xScale(d.label);
-        if (x == null) return null;
+        const y = yScale(d.value);
+        if (x == null || y == null) return null;
+        const offsetX = i === 0 ? 10 : 0;
+        const anchor = i === 0 ? "start" : "middle";
         return (
-          <text
-            key={i}
-            x={x}
-            y={y}
-            textAnchor="middle"
-            fontSize={13}
-            fill="#555"
-            style={{ pointerEvents: "none", userSelect: "none" }}
-          >
-            {d.label}
-          </text>
+          <g key={i}>
+            <text
+              x={x + offsetX}
+              y={y - 10}
+              textAnchor={anchor}
+              fontSize={16}
+              fill="#1976d2"
+              fontWeight="bold"
+              stroke="white"
+              strokeWidth={4}
+              strokeLinejoin="round"
+              paintOrder="stroke"
+              style={{ pointerEvents: "none", userSelect: "none" }}
+            >
+              {d.value}
+            </text>
+            <text
+              x={x}
+              y={dateY}
+              textAnchor="middle"
+              fontSize={13}
+              fill="#555"
+              stroke="white"
+              strokeWidth={3}
+              strokeLinejoin="round"
+              paintOrder="stroke"
+              style={{ pointerEvents: "none", userSelect: "none" }}
+            >
+              {d.label}
+            </text>
+          </g>
         );
       })}
     </>
   );
 };
 
-// 定義在元件外，避免每次 render 產生新的 component type reference
-// 在 LineChart 的 SVG context 內渲染，透過 chart hooks 取得座標
-const DataLabels = ({ chartData }) => {
-  const xScale = useXScale();
-  const yScale = useYScale();
+// 所有重計算集中在此，只在 hasOpened 後才掛載
+const TrendChartContent = ({ chartData, unit }) => {
+  const chartWidth = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, chartData.length * PX_PER_POINT));
+  const needsScroll = chartWidth >= MAX_WIDTH;
+
+  const refMins = chartData.map(d => d.referenceMin);
+  const refMaxs = chartData.map(d => d.referenceMax);
+  const hasRefMin = refMins.some(v => v != null);
+  const hasRefMax = refMaxs.some(v => v != null);
+
+  const dataValues = chartData.map(d => d.value);
+  const validRefMins = refMins.filter(v => v != null);
+  const validRefMaxs = refMaxs.filter(v => v != null);
+  const effectiveMin = Math.min(...dataValues, ...validRefMins);
+  const effectiveMax = Math.max(...dataValues, ...validRefMaxs);
+  const rangePad = (effectiveMax - effectiveMin) * 0.15 || effectiveMax * 0.1;
+  const yMin = Math.max(0, effectiveMin - rangePad);
+  const yMax = effectiveMax + rangePad;
+
+  const series = [
+    {
+      id: "main",
+      data: chartData.map(d => d.value),
+      showMark: true,
+      color: "#1976d2",
+      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
+    },
+  ];
+  if (hasRefMax) {
+    series.push({
+      id: "refMax",
+      data: refMaxs,
+      showMark: false,
+      color: "#e57373",
+      label: "上限",
+      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
+    });
+  }
+  if (hasRefMin) {
+    series.push({
+      id: "refMin",
+      data: refMins,
+      showMark: false,
+      color: "#388e3c",
+      label: "下限",
+      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
+    });
+  }
+
+  // 建立候選標籤索引，依重要性排序
+  // Tier 1：第一點、最後一點（保證可見）
+  // Tier 2：全域最大值、最小值
+  // Tier 3：超出上下限的異常點
+  const values = chartData.map(d => d.value);
+  const maxVal = Math.max(...values);
+  const minVal = Math.min(...values);
+  const added = new Set();
+  const candidateIndices = [];
+  const addIfNew = (i) => { if (!added.has(i)) { added.add(i); candidateIndices.push(i); } };
+
+  addIfNew(0);
+  addIfNew(chartData.length - 1);
+  chartData.forEach((d, i) => { if (d.value === maxVal || d.value === minVal) addIfNew(i); });
+  chartData.forEach((d, i) => {
+    const isAbove = d.referenceMax != null && d.value > d.referenceMax;
+    const isBelow = d.referenceMin != null && d.value < d.referenceMin;
+    if (isAbove || isBelow) addIfNew(i);
+  });
 
   return (
-    <>
-      {chartData.map((d, i) => {
-        const x = xScale(d.label);
-        const y = yScale(d.value);
-        if (x == null || y == null) return null;
-        // 第一個點：往右上偏移，避免與Y軸數值重疊
-        const offsetX = i === 0 ? 10 : 0;
-        const anchor = i === 0 ? "start" : "middle";
-        return (
-          <text
-            key={i}
-            x={x + offsetX}
-            y={y - 10}
-            textAnchor={anchor}
-            fontSize={16}
-            fill="#1976d2"
-            fontWeight="bold"
-            style={{ pointerEvents: "none", userSelect: "none" }}
-          >
-            {d.value}
-          </text>
-        );
-      })}
-    </>
+    <Box sx={needsScroll ? { overflowX: "auto", maxWidth: MAX_WIDTH } : {}}>
+      <LineChart
+        xAxis={[{
+          data: chartData.map(d => d.label),
+          scaleType: "point",
+          tickLabelStyle: { display: "none" },
+        }]}
+        yAxis={[{ min: yMin, max: yMax, tickLabelStyle: { fontSize: 15 } }]}
+        series={series}
+        height={420}
+        width={chartWidth}
+        margin={{ left: 65, right: 55, top: 30, bottom: 65 }}
+        slotProps={{ legend: { hidden: true } }}
+        tooltip={{ trigger: "axis" }}
+        sx={{
+          "& svg": { overflow: "visible" },
+          "& .MuiLineElement-series-refMax": {
+            strokeDasharray: "6 3",
+            strokeWidth: 1.5,
+          },
+          "& .MuiLineElement-series-refMin": {
+            strokeDasharray: "6 3",
+            strokeWidth: 1.5,
+          },
+        }}
+      >
+        <ChartLabels chartData={chartData} candidateIndices={candidateIndices} />
+      </LineChart>
+    </Box>
   );
 };
 
 const LabItemTrendPopover = ({ item, dates, children }) => {
   const [anchorEl, setAnchorEl] = useState(null);
+  const [hasOpened, setHasOpened] = useState(false);
   const closeTimer = useRef(null);
 
-  // 將 dates（新→舊）反轉為舊→新，只保留有數值的日期
+  // 輕量計算：只做資料整理，用於判斷是否要啟用 Popover
   const chartData = [...dates]
     .reverse()
     .map(d => {
@@ -95,55 +207,9 @@ const LabItemTrendPopover = ({ item, dates, children }) => {
 
   const unit = chartData[0]?.unit || "";
 
-  const refMins = chartData.map(d => d.referenceMin);
-  const refMaxs = chartData.map(d => d.referenceMax);
-  const hasRefMin = refMins.some(v => v != null);
-  const hasRefMax = refMaxs.some(v => v != null);
-
-  // Y 軸範圍：取資料值與上下限的聯集，加 15% padding，不低於 0
-  const dataValues = chartData.map(d => d.value);
-  const validRefMins = refMins.filter(v => v != null);
-  const validRefMaxs = refMaxs.filter(v => v != null);
-  const effectiveMin = Math.min(...dataValues, ...validRefMins);
-  const effectiveMax = Math.max(...dataValues, ...validRefMaxs);
-  const rangePad = (effectiveMax - effectiveMin) * 0.15 || effectiveMax * 0.1;
-  const yMin = Math.max(0, effectiveMin - rangePad);
-  const yMax = effectiveMax + rangePad;
-
-  const series = [
-    {
-      id: "main",
-      data: chartData.map(d => d.value),
-      showMark: true,
-      color: "#1976d2",
-      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
-    },
-  ];
-
-  if (hasRefMax) {
-    series.push({
-      id: "refMax",
-      data: refMaxs,
-      showMark: false,
-      color: "#e57373",
-      label: "上限",
-      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
-    });
-  }
-
-  if (hasRefMin) {
-    series.push({
-      id: "refMin",
-      data: refMins,
-      showMark: false,
-      color: "#388e3c",
-      label: "下限",
-      valueFormatter: (v) => v != null ? `${v}${unit ? ` ${unit}` : ""}` : "",
-    });
-  }
-
   const openPopover = (event) => {
     if (closeTimer.current) clearTimeout(closeTimer.current);
+    if (!hasOpened) setHasOpened(true); // 第一次開啟才觸發重計算與渲染
     setAnchorEl(event.currentTarget);
   };
 
@@ -188,34 +254,8 @@ const LabItemTrendPopover = ({ item, dates, children }) => {
           {unit ? ` (${unit})` : ""}
         </Typography>
 
-        <LineChart
-          xAxis={[{
-            data: chartData.map(d => d.label),
-            scaleType: "point",
-            tickLabelStyle: { display: "none" },
-          }]}
-          yAxis={[{ min: yMin, max: yMax, tickLabelStyle: { fontSize: 15 } }]}
-          series={series}
-          height={420}
-          width={660}
-          margin={{ left: 65, right: 55, top: 30, bottom: 65 }}
-          slotProps={{ legend: { hidden: true } }}
-          tooltip={{ trigger: "axis" }}
-          sx={{
-            "& svg": { overflow: "visible" },
-            "& .MuiLineElement-series-refMax": {
-              strokeDasharray: "6 3",
-              strokeWidth: 1.5,
-            },
-            "& .MuiLineElement-series-refMin": {
-              strokeDasharray: "6 3",
-              strokeWidth: 1.5,
-            },
-          }}
-        >
-          <DataLabels chartData={chartData} />
-          <XAxisLabels chartData={chartData} />
-        </LineChart>
+        {/* hasOpened 後才掛載 TrendChartContent，之後不再卸載，避免重複計算 */}
+        {hasOpened && <TrendChartContent chartData={chartData} unit={unit} />}
       </Popover>
     </>
   );

--- a/src/legacyContent.js
+++ b/src/legacyContent.js
@@ -18,6 +18,7 @@ window.lastInterceptedMasterMenuData = null; // 新增主選單數據
 window.lastInterceptedAdultHealthCheckData = null; // 新增成人預防保健資料
 window.lastInterceptedCancerScreeningData = null; // 新增四癌篩檢結果資料
 window.lastInterceptedHbcvdata = null; // 新增B、C肝炎專區資料
+window.lastInterceptedImue0080s05Data = null; // 新增 imue0080s05 資料（待分析）
 // window.lastInterceptedRehabilitationData = null; // 新增復健資料
 // window.lastInterceptedAcupunctureData = null; // 新增針灸資料
 // window.lastInterceptedSpecialChineseMedCareData = null; // 新增特殊中醫處置資料
@@ -503,6 +504,7 @@ const API_URL_PATTERNS = new Map([
   ["adultHealthCheck", "/imu/api/imue0140/imue0140s01/hpa-data"],
   ["cancerScreening", "/imu/api/imue0150/imue0150s01/hpa-data"],
   ["hbcvdata", "/imu/api/imue0180/imue0180s01/hbcv-data"],
+  ["imue0080s05", "/imu/api/imue0080/imue0080s05/get-data"],
   // ["rehabilitation", "/imu/api/imue0080/imue0080s02/get-data"],
   // ["acupuncture", "/imu/api/imue0100/imue0100s02/get-data"],
   // ["specialChineseMedCare", "/imu/api/imue0170/imue0170s02/get-data"]
@@ -527,6 +529,7 @@ const DataProcessor = {
     ["adultHealthCheck", "/imu/api/imue0140/imue0140s01/hpa-data"],
     ["cancerScreening", "/imu/api/imue0150/imue0150s01/hpa-data"],
     ["hbcvdata", "/imu/api/imue0180/imue0180s01/hbcv-data"],
+    ["imue0080s05", "/imu/api/imue0080/imue0080s05/get-data"],
     // ["rehabilitation", "/imu/api/imue0080/imue0080s02/get-data"],
     // ["acupuncture", "/imu/api/imue0100/imue0100s02/get-data"],
     // ["specialChineseMedCare", "/imu/api/imue0170/imue0170s02/get-data"]
@@ -548,6 +551,7 @@ const DataProcessor = {
     ["adultHealthCheck", "lastInterceptedAdultHealthCheckData"],
     ["cancerScreening", "lastInterceptedCancerScreeningData"],
     ["hbcvdata", "lastInterceptedHbcvdata"],
+    ["imue0080s05", "lastInterceptedImue0080s05Data"],
     // ["rehabilitation", "lastInterceptedRehabilitationData"],
     // ["acupuncture", "lastInterceptedAcupunctureData"],
     // ["specialChineseMedCare", "lastInterceptedSpecialChineseMedCareData"]
@@ -569,6 +573,7 @@ const DataProcessor = {
     ["adultHealthCheck", "saveAdultHealthCheckData"],
     ["cancerScreening", "saveCancerScreeningData"],
     ["hbcvdata", "saveHbcvdata"],
+    ["imue0080s05", "saveImue0080s05Data"],
     // ["rehabilitation", "saveRehabilitationData"],
     // ["acupuncture", "saveAcupunctureData"],
     // ["specialChineseMedCare", "saveSpecialChineseMedCareData"]
@@ -1526,6 +1531,7 @@ const apiPathMap = new Map([
   ["adultHealthCheck", "imue0140/imue0140s01/hpa-data"],
   ["cancerScreening", "imue0150/imue0150s01/hpa-data"],
   ["hbcvdata", "imue0180/imue0180s01/hbcv-data"],
+  ["imue0080s05", "imue0080/imue0080s05/get-data"],
   // ["rehabilitation", "imue0080/imue0080s02/get-data"],
   // ["acupuncture", "imue0160/imue0160s02/get-data"],
   // ["specialChineseMedCare", "imue0170/imue0170s02/get-data"]
@@ -1554,6 +1560,7 @@ function enhancedFetchData(dataType, options = {}) {
     "adultHealthCheck",
     "cancerScreening",
     "hbcvdata",
+    "imue0080s05",
     // "rehabilitation",
     // "acupuncture",
     // "specialChineseMedCare",
@@ -2006,6 +2013,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         adultHealthCheck: window.lastInterceptedAdultHealthCheckData,
         cancerScreening: window.lastInterceptedCancerScreeningData,
         hbcvdata: window.lastInterceptedHbcvdata,
+        imue0080s05: window.lastInterceptedImue0080s05Data,
         // rehabilitation: window.lastInterceptedRehabilitationData,
         // acupuncture: window.lastInterceptedAcupunctureData,
         // specialChineseMedCare: window.lastInterceptedSpecialChineseMedCareData,

--- a/src/localDataHandler.js
+++ b/src/localDataHandler.js
@@ -198,6 +198,11 @@ export async function processLocalData(jsonData, filename) {
         window.lastInterceptedHbcvdata = cleanData(JSON.parse(JSON.stringify(jsonData.hbcvdata)));
         loadedTypes.push('hbcvdata');
         triggerDataFetchCompleted('hbcvdata');
+      }],
+      ['imue0080s05', () => {
+        window.lastInterceptedImue0080s05Data = cleanData(JSON.parse(JSON.stringify(jsonData.imue0080s05)));
+        loadedTypes.push('imue0080s05');
+        triggerDataFetchCompleted('imue0080s05');
       }]
     ]);
 
@@ -238,6 +243,7 @@ export async function processLocalData(jsonData, filename) {
           adultHealthCheck: window.lastInterceptedAdultHealthCheckData,
           cancerScreening: window.lastInterceptedCancerScreeningData,
           hbcvdata: window.lastInterceptedHbcvdata,
+          imue0080s05: window.lastInterceptedImue0080s05Data,
           rehabilitation: window.lastInterceptedRehabilitationData,
           acupuncture: window.lastInterceptedAcupunctureData,
           specialChineseMedCare: window.lastInterceptedSpecialChineseMedCareData,

--- a/src/utils/labProcessorModules/abbreviationUtils.js
+++ b/src/utils/labProcessorModules/abbreviationUtils.js
@@ -46,7 +46,11 @@ const specialHandlers = new Map([
   ["09015C", (_, itemName) => {
     if (!itemName) return null;
     const gfrKeywords = ["GFR", "腎絲球過濾率", "Ccr"];
-    return gfrKeywords.some(keyword => itemName.includes(keyword)) ? "GFR" : "Cr";
+    if (!gfrKeywords.some(keyword => itemName.includes(keyword))) return "Cr";
+    // MDRD 舊公式
+    if (itemName.includes("MDRD")) return "eGFR(MDRD)";
+    // CKD-EPI 新公式或其他 GFR（預設視為新公式）
+    return "eGFR";
   }],
   
   // 特殊處理 09040C（尿液總蛋白相關）


### PR DESCRIPTION
## 本次更新摘要

### 1. fix: eGFR 公式區分與 Overview 顯示修正

健保署自 2026 年起將 eGFR 計算公式由 MDRD 統一改為 CKD-EPI，
但部分醫院仍同時回報兩種公式的數值，造成顯示混淆。

- `abbreviationUtils`: 09015C 項目依 itemName 是否包含 `MDRD` 關鍵字，
  分別標記為 `eGFR(MDRD)` 或 `eGFR`
- `Overview_LabTests`: 同一天同時有 CKD-EPI 與 MDRD 數值時，優先顯示 CKD-EPI
- `Overview_LabTests`: 同一天出現多個 eGFR 值（範圍值如 `11-11.29`）時，
  取小數位數較少的值（即健保署標準值），避免顯示不必要的精度

### 2. feat: 癌症篩檢新增 HPV 及胃癌篩檢項目

健保署 API 回應新增兩個篩檢欄位：
- `papillomavirus` → 顯示為 **HPV**（婦女人類乳突病毒檢測）
- `helicobacter` → 顯示為 **胃癌篩檢**（糞便抗原檢測幽門螺旋桿菌）

同步更新 `hasData` 判斷邏輯與渲染區塊。

### 3. feat: 新增 imue0080s05 API 端點攔截

新增 `/imu/api/imue0080/imue0080s05/get-data` 端點至攔截系統，
使開發模式下可擷取並下載該端點的完整回應 JSON，以利後續資料結構分析與功能規劃。

影響檔案：`background.js`、`legacyContent.js`、`localDataHandler.js`