### PR TITLE
fix: HbA1c 去重篩選改為不區分大小寫

### DIFF
--- a/src/utils/labProcessorModules/deduplicationUtils.js
+++ b/src/utils/labProcessorModules/deduplicationUtils.js
@@ -29,7 +29,7 @@ const deduplicateLabData = (labArray) => {
   if (labs09006C.length > 1) {
     // 找出包含 HbA1c 的項目
     const hba1cLabs = labs09006C.filter(lab =>
-      lab.assay_item_name && lab.assay_item_name.includes("HbA1c")
+      lab.assay_item_name && lab.assay_item_name.toLowerCase().includes("hba1c")
     );
 
     // 如果找到了包含 HbA1c 的項目，只保留這些項目


### PR DESCRIPTION
部分院所（如高醫岡山）回傳的 assay_item_name 為 "HbA1C"（大寫 C），
導致 deduplicateLabData 的大小寫敏感比對 .includes("HbA1c") 失敗， 該日期的 HbA1c 數值被誤刪而無法顯示。
改用 .toLowerCase().includes("hba1c") 修正。