### PR TITLE
Bugfix/race condition stale patient data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhitw-cloud-analyzer",
-  "version": "26.0514.1",
+  "version": "26.0527.1",
   "description": "NHITW Cloud Analyzer - 更好的健保雲端 2.0",
   "license": "Apache-2.0",
   "author": "The NHITW Cloud Analyzer Project Authors",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "更好的健保雲端 2.0",
-  "version": "26.0514.1",
+  "version": "26.0527.1",
   "description": "幫忙醫療人員快速瀏覽「健保雲端系統2.0」資料",
   "homepage_url": "https://github.com/leescot/NHITW_cloud_analyzer_react_MUI",
   "permissions": [

--- a/src/legacyContent.js
+++ b/src/legacyContent.js
@@ -1593,6 +1593,7 @@ function enhancedFetchData(dataType, options = {}) {
 
   // 主要的獲取邏輯
   const attemptFetch = () => {
+    const requestPatientId = currentPatientId; // 鎖定發出請求當下的病患
     return new Promise((resolve, reject) => {
       // 構建 API URL
       const apiPath = apiPathMap.get(dataType);
@@ -1708,6 +1709,12 @@ function enhancedFetchData(dataType, options = {}) {
             } else {
               rObject = Array.isArray(recordsArray) ? recordsArray : [];
               normalizedData = { rObject: rObject };
+            }
+
+            // 病患已切換，丟棄此筆過期回應
+            if (currentPatientId !== requestPatientId) {
+              resolve({ status: "stale", recordCount: 0, dataType });
+              return;
             }
 
             // 使用 Map 更新全局變數


### PR DESCRIPTION
# 問題描述

快速切換病患時，若前一位病患的某個 API（如癌症篩檢、成人健檢等較慢的端點）尚未回應，使用者已切換至下一位病患，該過期回應仍會在稍後抵達並覆蓋當前病患的資料，導致：

- 顯示的是新病患的姓名，但部分資料（如藥歷、檢驗）屬於舊病患
- 使用者快速連續切換多位病患時，症狀更加明顯
這是一個 race condition，在網路較慢或使用不穩定的新 API 端點時特別容易觸發。

# 修改內容
src/legacyContent.js
在 enhancedFetchData 的 attemptFetch 函式中：
1. fetch 送出時，將當下的 currentPatientId 鎖定為 closure 變數 requestPatientId
2. API 回應解析完成後，在寫入全域變數及觸發渲染前，比對 currentPatientId 是否仍與 requestPatientId 相同
3. 若不吻合（代表使用者已切換病患），直接丟棄該筆回應，不更新任何狀態

# 版本
26.0527.1